### PR TITLE
added installation / loading of httpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ This repo contains a QGIS plugin for downloading GeoParquet data from cloud sour
 
 ![gpq-download-demo5](https://github.com/user-attachments/assets/dc862317-1eb6-4ed4-b910-44ae22a60d71)
 
+The core idea is that GeoParquet can act more like a 'server', letting users download only the data they need, if you add a bit more smarts to the client. So this plugin uses [DuckDB](https://duckdb.org/) but abstracts all the details of forming the right queries to external sources, so users can just pick the data they want and pull it down with ease. And with GeoPackage output users don't even need to know anything about GeoParquet. More info is on the [plugin homepage](https://plugins.qgis.org/plugins/qgis_plugin_gpq_downloader/).
 
-The core idea is that GeoParquet can act more like a 'server', letting users download only the data they need, if you add a bit more smarts to the client. So this plugin uses [DuckDB](https://duckdb.org/) but abstracts all the details of forming the right queries to external sources, so users can just pick the data they want and pull it down with ease. And with GeoPackage output users don't even need to know anything about GeoParquet.
 
 ## Installation
 
 The easiest way to install the plugin file is to use the QGIS plugin manager. Just go to `Plugins > Manage and Install Plugins` and go to 
-the 'install' tab and search for 'GeoParquet Downloader'. Click on 'Install Plugin' and you should get it. Right now you also need to install DuckDB
+the 'install' tab and search for 'GeoParquet Downloader'. Click on 'Install Plugin' and you should get it. Alternatively you can download the zip file from
+one of the [releases](https://github.com/cholmes/qgis_plugin_gpq_downloader/releases) and 'install from zip' in QGIS. Right now you also need to install DuckDB
 to get things to work. 
 
 On Windows you can use the [QDuckDB plugin](https://oslandia.gitlab.io/qgis/qduckdb/) which includes a precompiled binary. They also document how to install it on [Linux](https://oslandia.gitlab.io/qgis/qduckdb/usage/installation.html#linux) and [Mac OS/X](https://oslandia.gitlab.io/qgis/qduckdb/usage/installation.html#macos).

--- a/qgis_plugin_gpq_downloader.py
+++ b/qgis_plugin_gpq_downloader.py
@@ -118,6 +118,8 @@ class Worker(QObject):
             else:
                 conn = duckdb.connect() 
 
+            conn.execute("INSTALL httpfs;")
+            conn.execute("LOAD httpfs;")
             conn.execute("INSTALL spatial;")
             conn.execute("LOAD spatial;")
 


### PR DESCRIPTION
Had an error on a fresh install because httpfs duckdb extension wasn't installed.

It seems like the 'install' steps are very lightweight if the extension is already installed, so I just call them for httpfs and spatial. But we could look into doing the install conditionally, checking for presence.