### PR TITLE
Potentially fix duckdb install

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,8 +30,11 @@ def ensure_duckdb():
     except ImportError:
         print("DuckDB not found or needs upgrade, attempting to install/upgrade...")
         try:
+            qgis_bin = os.path.dirname(sys.executable)
             if platform.system() == "Windows":
-                py_path = os.path.join(os.path.dirname(sys.executable), "python.exe")
+                py_path = os.path.join(qgis_bin, "python.exe")
+            elif platform.system() == "Darwin":
+                py_path = os.path.join(qgis_bin, "python3")
             else:
                 py_path = sys.executable
             subprocess.check_call([py_path, "-m", "pip", "install", "--user", "duckdb"])

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,8 @@
 import os
+import platform
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 def ensure_duckdb():
     try:
@@ -29,8 +30,11 @@ def ensure_duckdb():
     except ImportError:
         print("DuckDB not found or needs upgrade, attempting to install/upgrade...")
         try:
-            import pip
-            pip.main(['install', '--upgrade', 'duckdb>=1.1.0'])
+            if platform.system() == "Windows":
+                py_path = os.path.join(os.path.dirname(sys.executable), "python.exe")
+            else:
+                py_path = sys.executable
+            subprocess.check_call([py_path, "-m", "pip", "install", "--user", "duckdb"])
             
             # Force Python to reload all modules to pick up the new installation
             import importlib


### PR DESCRIPTION
Works on default QGIS install on Windows.

Untested on MacOS/Linux.

If it doesn't on any particular system, we probably need to figure out where the corresponding executable is located. Linux probably in the System Python install, on MacOS probably in the QGIS bin folder.

- [x] Windows (Matthias)
- [ ] Linux
- [ ] MacOS (Chris?)
- [ ] Others?