### PR TITLE
Add-geojson-output

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -11,7 +11,7 @@ description=This plugin connects to cloud-based GeoParquet data and downloads th
     of any online GeoParquet file or partition. It works best with 
     the bbox struct from GeoParquet 1.1, but any GeoParquet file 
     will work. You can save the output data as GeoParquet, 
-    GeoPackage, DuckDB, or FlatGeobuf.
+    GeoPackage, DuckDB, FlatGeobuf, GeoJSON, or Shapefile.
 
     The plugin does not require that your QGIS supports 
     GeoParquet, as you can download data as GeoPackage, but 

--- a/metadata.txt
+++ b/metadata.txt
@@ -11,7 +11,7 @@ description=This plugin connects to cloud-based GeoParquet data and downloads th
     of any online GeoParquet file or partition. It works best with 
     the bbox struct from GeoParquet 1.1, but any GeoParquet file 
     will work. You can save the output data as GeoParquet, 
-    GeoPackage, DuckDB, FlatGeobuf, GeoJSON, or Shapefile.
+    GeoPackage, DuckDB, FlatGeobuf, or GeoJSON.
 
     The plugin does not require that your QGIS supports 
     GeoParquet, as you can download data as GeoPackage, but 

--- a/qgis_plugin_gpq_downloader.py
+++ b/qgis_plugin_gpq_downloader.py
@@ -278,7 +278,7 @@ class Worker(QObject):
                         avg_row_size = conn.execute(f"SELECT AVG(json_length) FROM ({sample_query})").fetchone()[0]
                         estimated_size_mb = (row_count * avg_row_size) / (1024 * 1024)  # Convert to MB
                         
-                        if estimated_size_mb > 500:  # Warning threshold: 500MB
+                        if estimated_size_mb > 6144:  # Warning threshold: 6GB (6 * 1024 MB)
                             # Ask user if they want to continue
                             self.info.emit(
                                 f"Warning: The estimated GeoJSON file size is {estimated_size_mb:.1f}MB. "

--- a/qgis_plugin_gpq_downloader.py
+++ b/qgis_plugin_gpq_downloader.py
@@ -274,9 +274,14 @@ class Worker(QObject):
                     format_options = "(FORMAT GDAL, DRIVER 'GPKG');"
                 elif self.output_file.endswith(".fgb"):
                     format_options = "(FORMAT GDAL, DRIVER 'FlatGeobuf', SRS 'EPSG:4326');"
+                elif self.output_file.endswith(".geojson"):
+                    format_options = "(FORMAT GDAL, DRIVER 'GeoJSON');"
+                elif self.output_file.endswith(".shp"):
+                    format_options = "(FORMAT GDAL, DRIVER 'ESRI Shapefile');"
                 else:
                     self.error.emit("Unsupported file format.")
                 
+
                 print("Executing SQL query:")
                 print(copy_query + format_options)
                 conn.execute(copy_query + format_options)
@@ -824,7 +829,7 @@ class QgisPluginGeoParquet:
                 self.iface.mainWindow(),
                 "Save Data",
                 default_save_path,
-                "GeoParquet (*.parquet);;DuckDB Database (*.duckdb);;GeoPackage (*.gpkg);;FlatGeobuf (*.fgb)"
+                "GeoParquet (*.parquet);;DuckDB Database (*.duckdb);;GeoPackage (*.gpkg);;FlatGeobuf (*.fgb);;GeoJSON (*.geojson);;Shapefile (*.shp)"
             )
 
             if output_file:

--- a/qgis_plugin_gpq_downloader.py
+++ b/qgis_plugin_gpq_downloader.py
@@ -277,7 +277,7 @@ class Worker(QObject):
                 elif self.output_file.endswith(".geojson"):
                     format_options = "(FORMAT GDAL, DRIVER 'GeoJSON');"
                 elif self.output_file.endswith(".shp"):
-                    format_options = "(FORMAT GDAL, DRIVER 'ESRI Shapefile');"
+                    format_options = "(FORMAT GDAL, DRIVER 'ESRI Shapefile', SRS 'EPSG:4326');"
                 else:
                     self.error.emit("Unsupported file format.")
                 

--- a/qgis_plugin_gpq_downloader.py
+++ b/qgis_plugin_gpq_downloader.py
@@ -278,10 +278,16 @@ class Worker(QObject):
                         avg_row_size = conn.execute(f"SELECT AVG(json_length) FROM ({sample_query})").fetchone()[0]
                         estimated_size_mb = (row_count * avg_row_size) / (1024 * 1024)  # Convert to MB
                         
+                        # Format size message
+                        if estimated_size_mb >= 1024:  # If size is 1GB or larger
+                            size_str = f"{estimated_size_mb/1024:.1f}GB"
+                        else:
+                            size_str = f"{estimated_size_mb:.1f}MB"
+                        
                         if estimated_size_mb > 6144:  # Warning threshold: 6GB (6 * 1024 MB)
                             # Ask user if they want to continue
                             self.info.emit(
-                                f"Warning: The estimated GeoJSON file size is {estimated_size_mb:.1f}MB. "
+                                f"Warning: The estimated GeoJSON file size is {size_str}. "
                                 "Large GeoJSON files can be slow to process and load. "
                                 "Consider using GeoParquet or GeoPackage format instead.\n\n"
                                 "Do you want to continue with GeoJSON export?"


### PR DESCRIPTION
Extends the plugin's export capabilities by adding two new output formats:
- GeoJSON
- Shapefile

Updates both the metadata description and the file save dialog to include these new export options, providing users with more flexibility in data output formats.

Adds SRS specification to Shapefile export

Updates Shapefile export logic to include SRS definition (EPSG:4326), ensuring consistent spatial reference information.

Enhances interoperability and alignment with standard geospatial data practices.

Relates to extended export format support.