### PR TITLE
Make plugin Qt6 ready

### DIFF
--- a/gpq_downloader/dialog.py
+++ b/gpq_downloader/dialog.py
@@ -267,7 +267,7 @@ class DataSourceDialog(QDialog):
 
                 # Create progress dialog for validation
                 progress_dialog = QProgressDialog("Validating URL...", "Cancel", 0, 0, self)
-                progress_dialog.setWindowModality(Qt.WindowModal)
+                progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
 
                 # Create validation worker
                 self.validation_worker = ValidationWorker(url, self.iface, self.iface.mapCanvas().extent())
@@ -286,7 +286,7 @@ class DataSourceDialog(QDialog):
 
                 # Start validation
                 self.validation_thread.start()
-                progress_dialog.exec_()
+                progress_dialog.exec()
                 return
 
         # For other preset sources, we can skip validation
@@ -409,12 +409,12 @@ class DataSourceDialog(QDialog):
             "This dataset doesn't have a bbox column, which means downloads will be slower. "
             "GeoParquet 1.1 files with a bbox column work much better - tell your data provider to upgrade!\n\n"
             "Do you want to continue with the download?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
         validation_results = {"has_bbox": False, "schema": None}
-        if reply == QMessageBox.No:
+        if reply == QMessageBox.StandardButton.No:
             self.validation_complete.emit(
                 False, "Download cancelled by user.", validation_results
             )

--- a/gpq_downloader/metadata.txt
+++ b/gpq_downloader/metadata.txt
@@ -2,6 +2,7 @@
 name=GeoParquet Downloader (Overture, Source Coop & Custom Cloud)
 qgisMinimumVersion=3.16
 version=0.6.0
+supportsQt6=yes
 icon=icons/parquet-download.png
 about=Plugin for downloading GeoParquet data from cloud sources.
 description=This plugin connects to cloud-based GeoParquet data and downloads the portion in the current viewport.

--- a/gpq_downloader/plugin.py
+++ b/gpq_downloader/plugin.py
@@ -69,7 +69,7 @@ class QgisPluginGeoParquet:
         if not selected_name:
             dialog.overture_radio.setChecked(True)
         
-        if dialog.exec_() == QDialog.Accepted:
+        if dialog.exec() == QDialog.DialogCode.Accepted:
             # Get the selected URLs from the dialog
             urls = dialog.selected_urls
             extent = self.iface.mapCanvas().extent()
@@ -236,7 +236,7 @@ class QgisPluginGeoParquet:
                 layout.addWidget(button_box)
 
                 dialog.setLayout(layout)
-                dialog.exec_()
+                dialog.exec()
                 return
 
         layer_name = Path(output_file).stem  # Get filename without extension
@@ -325,7 +325,7 @@ class QgisPluginGeoParquet:
         proceed_button.clicked.connect(lambda: dialog.done(2))
 
         while True:
-            result = dialog.exec_()
+            result = dialog.exec()
             if result == 1:
                 selected_format = format_combo.currentText()
                 extension = selected_format.split("*")[1].rstrip(")")
@@ -342,7 +342,7 @@ class QgisPluginGeoParquet:
                 if output_file:
                     self.progress_dialog = QProgressDialog("Starting download...", "Cancel", 0, 0, self.iface.mainWindow())
                     self.progress_dialog.setWindowTitle("Downloading Data")
-                    self.progress_dialog.setWindowModality(Qt.NonModal)
+                    self.progress_dialog.setWindowModality(Qt.WindowModality.NonModal)
                     self.progress_dialog.setMinimumDuration(0)
                     
                     self.output_file = output_file
@@ -375,7 +375,7 @@ class QgisPluginGeoParquet:
             elif result == 2:
                 self.progress_dialog = QProgressDialog("Starting download...", "Cancel", 0, 0, self.iface.mainWindow())
                 self.progress_dialog.setWindowTitle("Downloading Data")
-                self.progress_dialog.setWindowModality(Qt.NonModal)
+                self.progress_dialog.setWindowModality(Qt.WindowModality.NonModal)
                 self.progress_dialog.setMinimumDuration(0)
                 
                 self.worker = Worker(
@@ -419,7 +419,7 @@ class QgisPluginGeoParquet:
             message, "Cancel", 0, 0, self.iface.mainWindow()
         )
         progress_dialog.setWindowTitle(title)
-        progress_dialog.setWindowModality(Qt.NonModal)
+        progress_dialog.setWindowModality(Qt.WindowModality.NonModal)
         progress_dialog.setMinimumDuration(0)
         return progress_dialog
 
@@ -473,7 +473,7 @@ class QgisPluginGeoParquet:
             "Cancel", 0, 0, self.iface.mainWindow()
         )
         self.progress_dialog.setWindowTitle("Downloading Data")
-        self.progress_dialog.setWindowModality(Qt.NonModal)
+        self.progress_dialog.setWindowModality(Qt.WindowModality.NonModal)
         self.progress_dialog.setMinimumDuration(0)
         
         # Create worker with layer name


### PR DESCRIPTION
Prepares the plugin to be used with Qt6 builds of QGIS. Tested on Windows (3.40; Qt6) and Fedora (Nightly; Qt5). 

Closes #67. 