### PR TITLE
Fixes for 0.7.x upgrades

### DIFF
--- a/gpq_downloader/dialog.py
+++ b/gpq_downloader/dialog.py
@@ -18,7 +18,7 @@ from qgis.PyQt.QtWidgets import (
 from qgis.PyQt.QtCore import pyqtSignal, Qt, QThread
 from qgis.core import QgsSettings
 import os
-from gpq_downloader.utils import ValidationWorker
+from .utils import ValidationWorker
 
 
 class DataSourceDialog(QDialog):

--- a/gpq_downloader/metadata.txt
+++ b/gpq_downloader/metadata.txt
@@ -1,7 +1,7 @@
 [general]
 name=GeoParquet Downloader (Overture, Source Coop & Custom Cloud)
 qgisMinimumVersion=3.16
-version=0.7.1
+version=0.7.2
 supportsQt6=yes
 icon=icons/parquet-download.png
 description=Plugin for downloading GeoParquet data from cloud sources.

--- a/gpq_downloader/plugin.py
+++ b/gpq_downloader/plugin.py
@@ -20,8 +20,8 @@ import os
 import datetime
 from pathlib import Path
 
-from gpq_downloader.dialog import DataSourceDialog
-from gpq_downloader.utils import Worker
+from .dialog import DataSourceDialog
+from .utils import Worker
 
 
 class QgisPluginGeoParquet:

--- a/gpq_downloader/utils.py
+++ b/gpq_downloader/utils.py
@@ -5,7 +5,7 @@ from qgis.PyQt.QtCore import pyqtSignal, QObject
 import os
 import duckdb
 
-from gpq_downloader import logger
+from . import logger
 
 
 def transform_bbox_to_4326(extent, source_crs):


### PR DESCRIPTION
Had some errors in 0.7.1. These fixes:

* Use relative module names, so the qgis_plugin_gpq_downloader directory continues to work.
* Removes the dummy plugin / attempt to deprecate the older plugin.