### PR TITLE
Extend-download-options-v2

### DIFF
--- a/gpq_downloader/icons/extent-draw-polygon.svg
+++ b/gpq_downloader/icons/extent-draw-polygon.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg4016"
+   sodipodi:docname="draw-polygon.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata4022">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4020" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="1005"
+     id="namedview4018"
+     showgrid="false"
+     inkscape:zoom="33"
+     inkscape:cx="11.969697"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4579"
+     inkscape:measure-start="7.94638,12.8686"
+     inkscape:measure-end="4.08579,12.8365" />
+  <linearGradient
+     gradientUnits="userSpaceOnUse"
+     x1="-10"
+     x2="-10"
+     y1="15"
+     y2="21"
+     id="linearGradient3996">
+    <stop
+       offset="0"
+       stop-color="#555753"
+       id="stop3992" />
+    <stop
+       offset="1"
+       stop-color="#555753"
+       stop-opacity="0"
+       id="stop3994" />
+  </linearGradient>
+  <g
+     id="g4579">
+    <path
+       inkscape:transform-center-y="0.074247532"
+       inkscape:transform-center-x="0.85518155"
+       d="M 19.528169,6.7173021 19.772119,16.805127 10.253412,20.154446 4.126578,12.136614 9.8586934,3.8320024 Z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="true"
+       sodipodi:arg2="-0.024177838"
+       sodipodi:arg1="-0.65249637"
+       sodipodi:r2="6.9443798"
+       sodipodi:r1="8.583725"
+       sodipodi:cy="11.929098"
+       sodipodi:cx="12.707794"
+       sodipodi:sides="5"
+       id="path4494"
+       style="display:inline;fill:none;stroke:#009da5;stroke-width:1.75040314;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="star"
+       transform="matrix(1.1275452,0,0,1.1578435,-1.5305419,-1.8941222)" />
+    <path
+       d="m 1.9119617,10.798093 h 2.7399348 v 2.813559 H 1.9119617 Z"
+       id="path4008"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:#5a5a5a;stroke:#323232;stroke-width:0.92550093;stroke-opacity:1;fill-opacity:1" />
+    <path
+       d="m 8.32053,1.2994302 h 2.739935 V 4.1129904 H 8.32053 Z"
+       id="path4012"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:#5a5a5a;stroke:#323232;stroke-width:0.92550105;stroke-opacity:1;fill-opacity:1" />
+    <path
+       style="display:inline;fill:#5a5a5a;stroke:#323232;stroke-width:0.92550105;stroke-opacity:1;fill-opacity:1"
+       inkscape:connector-curvature="0"
+       id="path844"
+       d="m 18.912805,4.7636482 h 2.739934 v 2.8135603 h -2.739934 z" />
+    <path
+       d="m 19.348104,15.826797 h 2.739934 v 2.813559 h -2.739934 z"
+       id="path846"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:#5a5a5a;stroke:#323232;stroke-width:0.92550105;stroke-opacity:1;fill-opacity:1" />
+    <path
+       style="display:inline;fill:#5a5a5a;stroke:#323232;stroke-width:0.92550105;stroke-opacity:1;fill-opacity:1"
+       inkscape:connector-curvature="0"
+       id="path848"
+       d="m 8.8283787,19.88701 h 2.7399343 v 2.81356 H 8.8283787 Z" />
+  </g>
+</svg>

--- a/gpq_downloader/icons/extent-select.svg
+++ b/gpq_downloader/icons/extent-select.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="extent-select.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="1005"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="33"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8" />
+  <g
+     transform="translate(0,-1028.3622)"
+     id="g8">
+    <path
+       d="M 1.4798758,1029.842 H 22.520123 v 19.0402 H 1.4798758 Z"
+       id="path2"
+       inkscape:connector-curvature="0"
+       style="fill:#e5e5e5;stroke:#424242;stroke-width:0.95975173;stroke-dasharray:1.91950336, 0.95975168" />
+    <path
+       d="M 2.9734817,1031.3356 H 17.602274 v 14.6288 H 2.9734817 Z"
+       overflow="visible"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="overflow:visible;fill:#91d9dd;fill-opacity:1;stroke:#009da5;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 22.652743,1044.0577 -12.756464,-6.9791 5.477553,13.6014 2.180887,-3.5312 4.312159,4.7134 1.633122,-1.5913 -4.408599,-4.6683 3.561343,-1.5449 z"
+       style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       id="path6"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/gpq_downloader/icons/extents.svg
+++ b/gpq_downloader/icons/extents.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="extents.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20">
+    <marker
+       style="overflow:visible"
+       inkscape:stockid="InfiniteLineEnd"
+       id="InfiniteLineEnd"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:isstock="true">
+      <g
+         id="g1099"
+         style="fill:#000000;stroke:#000000;stroke-opacity:1;fill-opacity:1">
+        <circle
+           id="circle1093"
+           r="0.8"
+           cy="0"
+           cx="3"
+           style="stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1" />
+        <circle
+           id="circle1095"
+           r="0.8"
+           cy="0"
+           cx="6.5"
+           style="stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1" />
+        <circle
+           id="circle1097"
+           r="0.8"
+           cy="0"
+           cx="10"
+           style="stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1" />
+      </g>
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="1005"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="27.812867"
+     inkscape:cx="13.52649"
+     inkscape:cy="11.952876"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g14" />
+  <g
+     transform="translate(0,-8)"
+     id="g14">
+    <path
+       style="display:inline;opacity:0.98999999;fill:none;stroke:#009da5;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:15.59193897;stroke-opacity:1"
+       d="m 5.3632631,11.504903 v -8e-5 L 19.239616,11.314532"
+       id="path1280"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.98999999;fill:none;stroke:#009da5;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:12.62;stroke-opacity:1"
+       d="M 22.14823,14.656178 V 25.200576"
+       id="path1278"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.98999999;fill:none;stroke:#009da5;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:14.66;stroke-opacity:0.99215686"
+       d="M 19.199954,28.68817 H 4.5124089"
+       id="path1276"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.98999999;fill:none;stroke:#009da5;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:12.9;stroke-opacity:0.99215686"
+       d="M 1.8517698,25.092712 V 14.707173"
+       id="path2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.98999999;fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:7.31856918"
+       d="m 22.151367,14.697074 v -3.385193 l -2.875,0.02829 m -14.8281246,0.14144 -2.5996094,0.02593 v 3.189531 m 0,10.433753 v 3.557282 h 2.5996094 m 14.8281246,0 h 2.875 v -3.557282"
+       id="path848"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccsc" />
+  </g>
+</svg>

--- a/gpq_downloader/map_tools.py
+++ b/gpq_downloader/map_tools.py
@@ -1,0 +1,150 @@
+import os
+from math import sqrt
+
+from qgis.core import (
+    QgsGeometry,
+    QgsPoint,
+    QgsPointXY,
+    QgsRectangle,
+    QgsWkbTypes,
+)
+from qgis.gui import QgsMapTool, QgsRubberBand
+from qgis.PyQt.QtCore import QPointF, QRect, Qt, pyqtSignal
+from qgis.PyQt.QtGui import QColor
+
+# Define colors for the rubber band
+RB_STROKE = QColor(0, 120, 215)  # Blue color
+RB_FILL = QColor(204, 235, 239, 100)  # Light blue with transparency
+
+
+class RectangleMapTool(QgsMapTool):
+    """Map tool for drawing rectangles"""
+    extentSelected = pyqtSignal(object)
+
+    def __init__(self, canvas):
+        QgsMapTool.__init__(self, canvas)
+
+        self.canvas = canvas
+        self.extent = None
+        self.dragging = False
+        self.rubber_band = None
+        self.select_rect = QRect()
+
+    def canvasPressEvent(self, event):
+        self.select_rect.setRect(0, 0, 0, 0)
+        self.rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.setFillColor(RB_FILL)
+        self.rubber_band.setStrokeColor(RB_STROKE)
+        self.rubber_band.setWidth(1)
+
+    def canvasMoveEvent(self, event):
+        if event.buttons() != Qt.LeftButton:
+            return
+
+        if not self.dragging:
+            self.dragging = True
+            self.select_rect.setTopLeft(event.pos())
+
+        self.select_rect.setBottomRight(event.pos())
+        self._set_rubber_band()
+
+    def canvasReleaseEvent(self, event):
+        # If the user simply clicked without dragging ignore this
+        if not self.dragging:
+            return
+
+        # Set valid values for rectangle's width and height
+        if self.select_rect.width() == 1:
+            self.select_rect.setLeft(self.select_rect.left() + 1)
+        if self.select_rect.height() == 1:
+            self.select_rect.setBottom(self.select_rect.bottom() + 1)
+
+        if self.rubber_band:
+            self._set_rubber_band()
+
+            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            del self.rubber_band
+            self.rubber_band = None
+
+        self.dragging = False
+
+        # Emit the selected extent
+        self.extentSelected.emit(self.extent)
+
+    def _set_rubber_band(self):
+        transform = self.canvas.getCoordinateTransform()
+
+        ll = transform.toMapCoordinates(
+            self.select_rect.left(), self.select_rect.bottom()
+        )
+        ur = transform.toMapCoordinates(
+            self.select_rect.right(), self.select_rect.top()
+        )
+
+        if self.rubber_band:
+            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            self.rubber_band.addPoint(ll, False)
+            self.rubber_band.addPoint(QgsPointXY(ur.x(), ll.y()), False)
+            self.rubber_band.addPoint(ur, False)
+            self.rubber_band.addPoint(QgsPointXY(ll.x(), ur.y()), True)
+            self.extent = QgsRectangle(ur, ll)
+
+
+class PolygonMapTool(QgsMapTool):
+    """Map tool for drawing polygons"""
+    polygonSelected = pyqtSignal(object)
+
+    def __init__(self, canvas):
+        QgsMapTool.__init__(self, canvas)
+
+        self.canvas = canvas
+        self.extent = None
+        self.rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.setFillColor(RB_FILL)
+        self.rubber_band.setStrokeColor(RB_STROKE)
+        self.rubber_band.setWidth(1)
+        self.vertex_count = 1  # two points are dropped initially
+
+    def canvasReleaseEvent(self, event):
+        if event.button() == Qt.RightButton:
+            if self.rubber_band is None or self.extent is None:
+                return
+            # Validate geometry before firing signal
+            self.extent.removeDuplicateNodes()
+            self.polygonSelected.emit(self.extent)
+            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            del self.rubber_band
+            self.rubber_band = None
+            self.vertex_count = 1  # two points are dropped initially
+            return
+        elif event.button() == Qt.LeftButton:
+            if self.rubber_band is None:
+                self.rubber_band = QgsRubberBand(
+                    self.canvas, QgsWkbTypes.PolygonGeometry
+                )
+                self.rubber_band.setFillColor(RB_FILL)
+                self.rubber_band.setStrokeColor(RB_STROKE)
+                self.rubber_band.setWidth(1)
+            self.rubber_band.addPoint(event.mapPoint())
+            self.extent = self.rubber_band.asGeometry()
+            self.vertex_count += 1
+
+    def canvasMoveEvent(self, event):
+        if self.rubber_band is None:
+            pass
+        elif not self.rubber_band.numberOfVertices():
+            pass
+        elif self.rubber_band.numberOfVertices() == self.vertex_count:
+            if self.vertex_count == 2:
+                mouse_vertex = self.rubber_band.numberOfVertices() - 1
+                self.rubber_band.movePoint(mouse_vertex, event.mapPoint())
+            else:
+                self.rubber_band.addPoint(event.mapPoint())
+        else:
+            mouse_vertex = self.rubber_band.numberOfVertices() - 1
+            self.rubber_band.movePoint(mouse_vertex, event.mapPoint())
+
+    def deactivate(self):
+        QgsMapTool.deactivate(self)
+        # Emit deactivated signal
+        self.deactivated.emit() 

--- a/gpq_downloader/map_tools.py
+++ b/gpq_downloader/map_tools.py
@@ -16,6 +16,55 @@ from qgis.PyQt.QtGui import QColor
 # Define colors for the rubber band
 RB_STROKE = QColor(0, 120, 215)  # Blue color
 RB_FILL = QColor(204, 235, 239, 100)  # Light blue with transparency
+HIGHLIGHT_STROKE = QColor(255, 165, 0)  # Orange color for highlighting
+HIGHLIGHT_FILL = QColor(255, 223, 186, 150)  # Light orange with transparency
+
+
+class AoiHighlighter:
+    """Class to highlight the selected AOI on the map canvas"""
+    
+    def __init__(self, canvas):
+        """Initialize the highlighter"""
+        self.canvas = canvas
+        self.rubber_band = None
+        
+    def highlight_aoi(self, geometry=None, extent=None):
+        """Display a highlighted AOI on the map canvas
+        
+        Args:
+            geometry (QgsGeometry): The geometry to highlight
+            extent (QgsRectangle): The extent to highlight if no geometry is provided
+        """
+        # Clean up any existing rubber band
+        self.clear()
+        
+        # Create a new rubber band
+        self.rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.setFillColor(HIGHLIGHT_FILL)
+        self.rubber_band.setStrokeColor(HIGHLIGHT_STROKE)
+        self.rubber_band.setWidth(2)
+        
+        if geometry:
+            # Use provided geometry
+            self.rubber_band.setToGeometry(geometry, None)
+        elif extent:
+            # Convert extent to polygon geometry
+            rect_geom = QgsGeometry.fromRect(extent)
+            self.rubber_band.setToGeometry(rect_geom, None)
+        else:
+            # No geometry or extent provided, don't show anything
+            self.clear()
+            return
+            
+        # Make sure the rubber band is visible
+        self.rubber_band.show()
+        
+    def clear(self):
+        """Clear the highlighted area"""
+        if self.rubber_band:
+            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+            self.canvas.refresh()
+            self.rubber_band = None
 
 
 class PolygonMapTool(QgsMapTool):

--- a/gpq_downloader/map_tools.py
+++ b/gpq_downloader/map_tools.py
@@ -2,6 +2,7 @@ import os
 from math import sqrt
 
 from qgis.core import (
+    QgsCircle,
     QgsGeometry,
     QgsPoint,
     QgsPointXY,
@@ -15,79 +16,6 @@ from qgis.PyQt.QtGui import QColor
 # Define colors for the rubber band
 RB_STROKE = QColor(0, 120, 215)  # Blue color
 RB_FILL = QColor(204, 235, 239, 100)  # Light blue with transparency
-
-
-class RectangleMapTool(QgsMapTool):
-    """Map tool for drawing rectangles"""
-    extentSelected = pyqtSignal(object)
-
-    def __init__(self, canvas):
-        QgsMapTool.__init__(self, canvas)
-
-        self.canvas = canvas
-        self.extent = None
-        self.dragging = False
-        self.rubber_band = None
-        self.select_rect = QRect()
-
-    def canvasPressEvent(self, event):
-        self.select_rect.setRect(0, 0, 0, 0)
-        self.rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
-        self.rubber_band.setFillColor(RB_FILL)
-        self.rubber_band.setStrokeColor(RB_STROKE)
-        self.rubber_band.setWidth(1)
-
-    def canvasMoveEvent(self, event):
-        if event.buttons() != Qt.LeftButton:
-            return
-
-        if not self.dragging:
-            self.dragging = True
-            self.select_rect.setTopLeft(event.pos())
-
-        self.select_rect.setBottomRight(event.pos())
-        self._set_rubber_band()
-
-    def canvasReleaseEvent(self, event):
-        # If the user simply clicked without dragging ignore this
-        if not self.dragging:
-            return
-
-        # Set valid values for rectangle's width and height
-        if self.select_rect.width() == 1:
-            self.select_rect.setLeft(self.select_rect.left() + 1)
-        if self.select_rect.height() == 1:
-            self.select_rect.setBottom(self.select_rect.bottom() + 1)
-
-        if self.rubber_band:
-            self._set_rubber_band()
-
-            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
-            del self.rubber_band
-            self.rubber_band = None
-
-        self.dragging = False
-
-        # Emit the selected extent
-        self.extentSelected.emit(self.extent)
-
-    def _set_rubber_band(self):
-        transform = self.canvas.getCoordinateTransform()
-
-        ll = transform.toMapCoordinates(
-            self.select_rect.left(), self.select_rect.bottom()
-        )
-        ur = transform.toMapCoordinates(
-            self.select_rect.right(), self.select_rect.top()
-        )
-
-        if self.rubber_band:
-            self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
-            self.rubber_band.addPoint(ll, False)
-            self.rubber_band.addPoint(QgsPointXY(ur.x(), ll.y()), False)
-            self.rubber_band.addPoint(ur, False)
-            self.rubber_band.addPoint(QgsPointXY(ll.x(), ur.y()), True)
-            self.extent = QgsRectangle(ur, ll)
 
 
 class PolygonMapTool(QgsMapTool):

--- a/gpq_downloader/plugin.py
+++ b/gpq_downloader/plugin.py
@@ -77,6 +77,9 @@ class QgisPluginGeoParquet:
         self.worker_thread = None
         
         dialog = DataSourceDialog(self.iface.mainWindow(), self.iface)
+        
+        # Pass the QGIS interface to the dialog for map tools
+        dialog.iface = self.iface
 
         selected_name = QgsSettings().value("gpq_downloader/radio_selection", section=QgsSettings.Plugins)
         for button in [dialog.overture_radio, dialog.sourcecoop_radio, dialog.other_radio, dialog.custom_radio]:

--- a/gpq_downloader/utils.py
+++ b/gpq_downloader/utils.py
@@ -1,6 +1,6 @@
 import json
 
-from qgis.core import QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject
+from qgis.core import QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsGeometry
 from qgis.PyQt.QtCore import pyqtSignal, QObject
 import os
 import duckdb
@@ -40,17 +40,17 @@ class Worker(QObject):
     percent = pyqtSignal(int)
     file_size_warning = pyqtSignal(float)  # Signal for file size warnings (in MB)
 
-    def __init__(self, dataset_url, extent, output_file, iface, validation_results, layer_name=None):
+    def __init__(self, dataset_url, extent, output_file, iface, validation_results, layer_name=None, aoi_geometry=None):
         super().__init__()
         self.dataset_url = dataset_url
         self.extent = extent
         self.output_file = output_file
         self.iface = iface
-        #logger.log(f"Worker __init__ received validation_results: {validation_results}")
         self.validation_results = validation_results
         self.killed = False
-        self.layer_name = layer_name  # Ensure this is included if needed
-        self.size_warning_accepted = False  # Ensure this is False on initialization
+        self.layer_name = layer_name
+        self.size_warning_accepted = False
+        self.aoi_geometry = aoi_geometry
 
     def get_bbox_info_from_metadata(self, conn):
         """Read GeoParquet metadata to find bbox column info"""
@@ -102,7 +102,13 @@ class Worker(QObject):
             source_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
             bbox = transform_bbox_to_4326(self.extent, source_crs)
 
-            # Log validation results dictionary at the beginning of run
+            # Log the dataset URL and aoi_geometry for debugging
+            logger.log(f"Processing dataset: {self.dataset_url}")
+            if self.aoi_geometry:
+                logger.log(f"Using AOI geometry: {self.aoi_geometry.asWkt()}")
+            else:
+                logger.log("No AOI geometry provided.")
+
             #logger.log(f"Full validation_results at start of run: {self.validation_results}")
 
             conn = duckdb.connect()
@@ -228,6 +234,27 @@ class Worker(QObject):
                                             {bbox.xMinimum()} {bbox.yMinimum()}))')
                     )
                     """
+
+                # Additional filtering with aoi_geometry if available
+                if self.aoi_geometry is not None:
+                    # Create a temporary clone for transformation to WGS 1984 (EPSG:4326)
+                    dest_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+                    source_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+                    
+                    # Log the source and destination CRS for debugging
+                    logger.log(f"Source CRS: {source_crs.authid()}, Destination CRS: {dest_crs.authid()}")
+                    
+                    # Clone and transform only for the SQL query
+                    transformed_geom = QgsGeometry(self.aoi_geometry)
+                    transform = QgsCoordinateTransform(source_crs, dest_crs, QgsProject.instance())
+                    transformed_geom.transform(transform)
+                    
+                    # Use the transformed geometry for the SQL query
+                    aoi_wkt = transformed_geom.asWkt()
+                    where_clause += f" AND ST_Intersects(\"{geometry_column}\", ST_GeomFromText('{aoi_wkt}'))"
+                    
+                    # Log the updated where_clause for debugging
+                    logger.log(f"Applying AOI geometry filter: {aoi_wkt}")
 
                 # Base query
                 base_query = f"""


### PR DESCRIPTION
It was easier to start over from my last PR on #10, so i'll delete that one!

This update adds the ability for users to define the area of interest they would like to download. The first button, Extent, allows them to set the bounding box for the download based on either the map canvas or the active data layer.

The second button, Draw, lets users define a custom polygon, which is then used as part of the spatial filter in the data download.

I haven’t had time to add a third button yet, that would use the geometry of any selected features.

