### PR TITLE
Fix #80: include building_part in Overture Buildings

### DIFF
--- a/gpq_downloader/data/presets.json
+++ b/gpq_downloader/data/presets.json
@@ -1,7 +1,7 @@
 {
     "overture": {
         "buildings": {
-            "url_template": "s3://overturemaps-us-west-2/release/{release}/theme=buildings/type=building/*",
+            "url_template": "s3://overturemaps-us-west-2/release/{release}/theme=buildings/type=building*/*",
             "info_url": "https://docs.overturemaps.org/reference/buildings",
             "needs_validation": false
         },

--- a/gpq_downloader/utils.py
+++ b/gpq_downloader/utils.py
@@ -129,7 +129,14 @@ class Worker(QObject):
                     conn.execute("LOAD spatial;")
 
                 # Get schema early as we need it for both column names and bbox check
-                schema_query = f"DESCRIBE SELECT * FROM read_parquet('{self.dataset_url}')"
+                use_union_by_name = "*" in self.dataset_url
+                read_parquet_sql = (
+                    f"read_parquet('{self.dataset_url}', union_by_name=true)"
+                    if use_union_by_name
+                    else f"read_parquet('{self.dataset_url}')"
+                )
+
+                schema_query = f"DESCRIBE SELECT * FROM {read_parquet_sql}"
                 schema_result = conn.execute(schema_query).fetchall()
                 self.validation_results['schema'] = schema_result
                 
@@ -268,7 +275,7 @@ class Worker(QObject):
                 # Base query
                 base_query = f"""
                 CREATE TABLE {table_name} AS (
-                    {select_query} FROM read_parquet('{self.dataset_url}')
+                    {select_query} FROM {read_parquet_sql}
                     {where_clause}
                 ) 
                 """
@@ -588,7 +595,15 @@ class ValidationWorker(QObject):
                 return
 
             self.progress.emit("Checking data format...")
-            schema_query = f"DESCRIBE SELECT * FROM read_parquet('{self.dataset_url}')"
+
+            use_union_by_name = "*" in self.dataset_url
+            read_parquet_sql = (
+                f"read_parquet('{self.dataset_url}', union_by_name=true)"
+                if use_union_by_name
+                else f"read_parquet('{self.dataset_url}')"
+            )
+            
+            schema_query = f"DESCRIBE SELECT * FROM {read_parquet_sql}"
             schema_result = conn.execute(schema_query).fetchall()
 
             # Update validation results with schema


### PR DESCRIPTION
Fixes #80

Buildings preset uses type=building*/*

DuckDB read_parquet uses union_by_name=true for glob URLs to handle mixed schemas robustly

Manual verification: layer contains type=building and type=building_part