### PR TITLE
Add developer setup script and docs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,88 @@
+# Developing the GeoParquet Downloader Plugin
+
+## Quick Start
+
+### 1. Link the plugin to QGIS
+
+Instead of copying files into QGIS manually, create a symlink so QGIS loads the code directly from your checkout:
+
+```bash
+bash scripts/setup-dev.sh
+```
+
+This replaces any installed copy with a symlink. Your edits are immediately available to QGIS.
+
+### 2. Install Plugin Reloader
+
+In QGIS, go to **Plugins > Manage and Install Plugins**, search for **Plugin Reloader**, and install it. This lets you reload the plugin in one click without restarting QGIS.
+
+Configure it to reload `qgis_plugin_gpq_downloader`:
+- Go to **Plugins > Plugin Reloader > Configure**
+- Select the plugin from the dropdown
+
+### 3. Development cycle
+
+1. Edit code in your editor
+2. In QGIS, press the Plugin Reloader button (or **Plugins > Plugin Reloader > Reload**)
+3. Test your changes
+
+No file copying. No QGIS restart (in most cases).
+
+**Note:** Changes to `__init__.py` or adding new dependencies require a full QGIS restart.
+
+## Testing a PR
+
+```bash
+# Fetch and checkout the PR
+git fetch origin pull/<PR_NUMBER>/head:pr-<PR_NUMBER>
+git checkout pr-<PR_NUMBER>
+
+# In QGIS, reload the plugin — done
+```
+
+Since the symlink points to your repo, switching branches instantly updates what QGIS sees.
+
+## Running Tests
+
+```bash
+# Install dev dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest gpq_downloader/tests/
+
+# With coverage
+pytest --cov=gpq_downloader gpq_downloader/tests/
+```
+
+Tests require a QGIS environment. The CI runs them inside a QGIS Docker container (see `.github/workflows/tests.yml`).
+
+## Project Structure
+
+```
+qgis_plugin_gpq_downloader/       # repo root
+├── gpq_downloader/               # plugin source (this is what QGIS loads)
+│   ├── __init__.py               # plugin entry point (classFactory)
+│   ├── plugin.py                 # main plugin class
+│   ├── dialog.py                 # UI dialog
+│   ├── utils.py                  # download/validation workers
+│   ├── logger.py                 # logging utility
+│   ├── metadata.txt              # QGIS plugin metadata & version
+│   ├── data/presets.json         # pre-configured data sources
+│   ├── icons/                    # plugin icons
+│   └── tests/                    # test suite
+├── scripts/setup-dev.sh          # dev environment setup
+├── make_release.sh               # build release zip
+├── pyproject.toml                # Python project config
+└── DEVELOPING.md                 # this file
+```
+
+**Naming note:** The source directory is `gpq_downloader/` but QGIS knows the plugin as `qgis_plugin_gpq_downloader` (the release script handles the rename). The setup script creates the symlink with the correct name.
+
+## Making a Release
+
+```bash
+bash make_release.sh
+```
+
+This creates a zip with the version from `metadata.txt`, ready to upload to the QGIS Plugin Repository.

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Sets up a symlink so QGIS loads the plugin directly from this repo.
+# After running this, code edits are immediately available in QGIS
+# (just reload the plugin — no manual file copying needed).
+#
+
+set -e
+
+PLUGIN_NAME="qgis_plugin_gpq_downloader"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_DIR="${REPO_DIR}/gpq_downloader"
+
+# Detect QGIS plugins directory
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    PLUGINS_DIR="$HOME/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins"
+elif [[ "$OSTYPE" == "linux"* ]]; then
+    PLUGINS_DIR="$HOME/.local/share/QGIS/QGIS3/profiles/default/python/plugins"
+else
+    echo "Error: Unsupported platform. On Windows, create the symlink manually:"
+    echo "  mklink /D \"%APPDATA%\\QGIS\\QGIS3\\profiles\\default\\python\\plugins\\${PLUGIN_NAME}\" \"${SOURCE_DIR}\""
+    exit 1
+fi
+
+LINK_PATH="${PLUGINS_DIR}/${PLUGIN_NAME}"
+
+echo "Source:  ${SOURCE_DIR}"
+echo "Target:  ${LINK_PATH}"
+echo ""
+
+# Check source exists
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Error: Source directory not found: ${SOURCE_DIR}"
+    exit 1
+fi
+
+# Handle existing installation
+if [ -L "$LINK_PATH" ]; then
+    EXISTING_TARGET="$(readlink "$LINK_PATH")"
+    if [ "$EXISTING_TARGET" = "$SOURCE_DIR" ]; then
+        echo "Symlink already exists and points to the right place. Nothing to do."
+        exit 0
+    fi
+    echo "Existing symlink points to: ${EXISTING_TARGET}"
+    echo "Replacing with link to this repo."
+    rm "$LINK_PATH"
+elif [ -d "$LINK_PATH" ]; then
+    BACKUP="${LINK_PATH}.backup.$(date +%Y%m%d%H%M%S)"
+    echo "Found existing plugin installation (not a symlink)."
+    echo "Backing up to: ${BACKUP}"
+    mv "$LINK_PATH" "$BACKUP"
+elif [ ! -d "$PLUGINS_DIR" ]; then
+    echo "Creating plugins directory: ${PLUGINS_DIR}"
+    mkdir -p "$PLUGINS_DIR"
+fi
+
+# Create the symlink
+ln -s "$SOURCE_DIR" "$LINK_PATH"
+echo "Symlink created."
+echo ""
+echo "Next steps:"
+echo "  1. Restart QGIS (or reload the plugin if you have Plugin Reloader installed)"
+echo "  2. Install 'Plugin Reloader' from the QGIS Plugin Manager for fast reloads"
+echo "     (Plugins > Manage and Install Plugins > search 'Plugin Reloader')"
+echo ""
+echo "See DEVELOPING.md for the full development workflow."


### PR DESCRIPTION
## Summary

- Adds `scripts/setup-dev.sh` — creates a symlink so QGIS loads the plugin directly from your repo checkout (no manual file copying)
- Adds `DEVELOPING.md` — documents the dev workflow: setup, edit/reload cycle, testing PRs, running tests, making releases

The setup script detects the platform, backs up any existing plugin installation, and creates the symlink with the correct name (`qgis_plugin_gpq_downloader` → `gpq_downloader/`).

## Test plan

- [x] Ran `setup-dev.sh` on macOS — symlink created, old install backed up
- [x] Ran script again — correctly detected existing symlink, no-op
- [ ] Verify QGIS loads the plugin via the symlink after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)